### PR TITLE
Issue #27 - proposal to shift anchors

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -36,6 +36,7 @@
 
   <script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
   <script src="https://cdn.rawgit.com/google/code-prettify/master/loader/prettify.css"></script>
+  <script type="application/javascript" src="https://code.jquery.com/jquery-1.12.3.min.js"></script>
 
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
 
@@ -50,5 +51,20 @@
     <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
   <![endif]-->
+
+  <script type="application/javascript">
+    $(function() {
+      $('a.anchor[href]:not(:has([name]))').each(function () {
+        var a = $(this), name = (a.attr('href') || '').substring(1);
+        a.removeAttr('href');
+        a.attr('name', name);
+        a.attr('id', name);
+        $('#' + name).removeAttr('id');
+      });
+      if((document.location.hash || '').length) {
+        document.location = document.location.hash;
+      }
+    });
+  </script>
 
 </head>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -587,10 +587,43 @@ pre {
     }
 }
 
+
+/**
+ * Ensure we can see the section titles when clicking on
+ * an anchor link, for pages where the top banner is there
+ * (i.e. documentation page)
+ * See: http://stackoverflow.com/questions/10732690/offsetting-an-html-anchor-to-adjust-for-fixed-header
+ */
+a.anchor {
+  display: block;
+  position: relative;
+  /*visibility: hidden;*/
+  top: -70px;
+}
+
 /**
  * Section anchors for Asciidoc
- */
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor:before,h2>a.anchor:before,h3>a.anchor:before,#toctitle>a.anchor:before,.sidebarblock>.content>.title>a.anchor:before,h4>a.anchor:before,h5>a.anchor:before,h6>a.anchor:before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
- 
+
+#content h1 > a.anchor, h2 > a.anchor, h3 > a.anchor, #toctitle > a.anchor, .sidebarblock > .content > .title > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor {
+  position: absolute;
+  z-index: 1001;
+  width: 1.5ex;
+  margin-left: -1.5ex;
+  display: block;
+  text-decoration: none !important;
+  visibility: hidden;
+  text-align: center;
+  font-weight: 400
+}
+
+#content h1 > a.anchor:before, h2 > a.anchor:before, h3 > a.anchor:before, #toctitle > a.anchor:before, .sidebarblock > .content > .title > a.anchor:before, h4 > a.anchor:before, h5 > a.anchor:before, h6 > a.anchor:before {
+  content: "\00A7";
+  font-size: .85em;
+  display: block;
+  padding-top: .1em
+}
+
+#content h1:hover > a.anchor, #content h1 > a.anchor:hover, h2:hover > a.anchor, h2 > a.anchor:hover, h3:hover > a.anchor, #toctitle:hover > a.anchor, .sidebarblock > .content > .title:hover > a.anchor, h3 > a.anchor:hover, #toctitle > a.anchor:hover, .sidebarblock > .content > .title > a.anchor:hover, h4:hover > a.anchor, h4 > a.anchor:hover, h5:hover > a.anchor, h5 > a.anchor:hover, h6:hover > a.anchor, h6 > a.anchor:hover {
+  visibility: visible
+}
+*/


### PR DESCRIPTION
proposal to shift anchors to not hide the top of the scrolled-to sections.

This fix changes:

```
<h3 id="code-cache-code-elements”>
    <a class="anchor" href="#code-cache-code-elements"></a>
    <code>&lt;cache&gt;</code> elements
</h3>
```

to:

```
<h3>
    <a class="anchor" name="code-cache-code-elements" id="code-cache-code-elements"></a>
    <code>&lt;cache&gt;</code> elements
</h3>
```

and also applies a CSS to shift the anchor `<a name...>` 70px above the section, to account for the floating banner.

This solves issue #27 and is compatible with normal anchors like we have in the documentation page at [http://localhost:4000/documentation/#historical_versions](http://localhost:4000/documentation/#historical_versions)

The real fix would be to control the asciidoc generation though...