### PR TITLE
Added support for automatic dependency download with bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _site
 _eh3
 documentation/3.0
 .idea
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gem 'github-pages'
+gem 'jekyll-asciidoc'
+gem 'jekyll-sitemap'
+gem 'nokogiri'
+gem 'asciidoctor'
+gem 'jekyll-asciidoc'
+gem 'jekyll-sitemap'

--- a/README.md
+++ b/README.md
@@ -8,23 +8,21 @@ This is the source code/files for the ehcache.org website.  The files in this re
 * Install Jekyll if you have not - follow instructions on the Jekyll home page (after first installing Ruby)
 [http://jekyllrb.com/](http://jekyllrb.com/)
 
-* After installing jekyll, install some gems:
-  * nokogiri : "gem install nokogiri"
-  * asciidoctor: " gem install jasciidoctor"
-  * jekyll-asciidoc: " gem install jekyll-asciidoc"
-  * jekyll-sitemap: " gem install jekyll-sitemap"
+* Run `gem install bundle`
 
 * Clone this repository to your local system (if you're going to contribute content, fork it first, and clone that)
 * cd into the "ehcache.github.io" directory
 * "git checkout ehcache.org" to switch to this branch
 
+* Install dependencies with: `bundle install`
 
 * To generate the *full* site including Ehcache 3 docs, you need to do the following:
   * within the root your clone of this repository, the contents of ehcache3 repository needs to be linked/or copied as "_eh3"
   * within the root your clone of this repository, the contents of ehcache3 repository's docs/src/docs/asciidoc/user folder needs to be linked/or copied as "documentation/3.0"
 
-* To generate and view (locally serve) the site "jekyll serve -w"   ( then point your browser at http://localhost:4000" )
-* To simply generate the site "jekyll build"  
+* To generate and view (locally serve) the site "bundle exec jekyll serve -w"   ( then point your browser at http://localhost:4000" )
+
+* To simply generate the site "jekyll build"
 
 ---
 


### PR DESCRIPTION
With this PR, the only thing needed is to have bundle installed. (`gem install bundle`).

Then, after a repository clone, run:

```
> bundle install
> bundle exec jekyll serve -w
```