### PR TITLE
#45 Visual clue to indicate old, current and future documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,10 @@ asciidoctor:
     - idprefix
     - idseparator=-
 
+documentation:
+    ehcache:
+      current: "3.0"
+      future: "3.1"
 
 defaults:
   -

--- a/_layouts/docs3x_page.html
+++ b/_layouts/docs3x_page.html
@@ -8,7 +8,7 @@ active_menu_id: ehc_mnu_docs
 
 <br/>
 
-<div class="container-fluid">
+<div class="container-fluid ehcache-documentation v{{ page.ehc_version }} {% if site.documentation.ehcache.current == page.ehc_version %} current {% else %} {% if site.documentation.ehcache.future == page.ehc_version %} future {% else %} old {% endif %} {% endif %}">
 
 
   <div class="row row-offcanvas row-offcanvas-left">
@@ -53,7 +53,18 @@ active_menu_id: ehc_mnu_docs
     <div class="col-xs-12 col-sm-9">
       <header class="post-header">
         {% if page.no_title_on_main_layout %} {% else %}
-        <h1 class="post-title">{% if page.visible_title %}{{ page.visible_title  | replace: '!DOC_VERSION!', page.ehc_version }} {% else %}{{ page.title  | replace: '!DOC_VERSION!', page.ehc_version }}{% endif %}</h1>
+        <h1 class="post-title">
+            <span>{% if page.visible_title %}{{ page.visible_title  | replace: '!DOC_VERSION!', page.ehc_version }} {% else %}{{ page.title  | replace: '!DOC_VERSION!', page.ehc_version }}{% endif %}</span>
+            {% if site.documentation.ehcache.current == page.ehc_version %}
+            <span class="current">CURRENT</span>
+            {% else %}
+            {% if site.documentation.ehcache.future == page.ehc_version %}
+            <span class="future">CURRENT:&nbsp;&nbsp;<a href="/documentation/{{site.documentation.ehcache.current}}">{{site.documentation.ehcache.current}}</a></span>
+            {% else %}
+            <span class="old">CURRENT:&nbsp;&nbsp;<a href="/documentation/{{site.documentation.ehcache.current}}">{{site.documentation.ehcache.current}}</a></span>
+            {% endif %}
+            {% endif %}
+        </h1>
         <hr/>
         {% endif %}
       </header>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -671,3 +671,24 @@ pre {
     border-bottom: none;
   }
 }
+
+.ehcache-documentation {
+
+  .current {
+    float: right;
+    color: limegreen;
+    font-size: 14px;
+  }
+
+  .future {
+    float: right;
+    color: orange;
+    font-size: 14px;
+  }
+
+  .old {
+    float: right;
+    color: red;
+    font-size: 14px;
+  }
+}


### PR DESCRIPTION
- adds some classes on the documentation layout to help changing the CSS based on version. Added class: `ehcache-documentation`, `vX.Y`, `current` or `old` or `future`
- added a color clue on the top right corner of the title, with a link to the latest version for old doc, or green if it is the latest, or orange for future

__Example of current doc:__

![](http://i.imgur.com/AYs3O4w.png)

__Example of old doc:__

![](http://i.imgur.com/DNI7yLx.png)

__Example of future doc:__

![](http://i.imgur.com/ot90kkl.png)