### PR TITLE
Script to automatically figure out which subdirectories are required …

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -96,6 +96,7 @@ defaults:
       layout: "docs3x_page"
       ehc_version: "3.0"
       ehc_javadoc_version: "3.0.3"
+      ehc_checkout_dir_var: "sourcedir"
   -
     scope:
       path: "documentation/3.1"
@@ -104,3 +105,4 @@ defaults:
       layout: "docs3x_page"
       ehc_version: "3.1"
       ehc_javadoc_version: "3.1.1"
+      ehc_checkout_dir_var: "sourcedir31"

--- a/git_clone_javadoc.rb
+++ b/git_clone_javadoc.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+
+###############################################################################
+# Big hack to parse _config.yml and figure out automatically what branches of
+# ehcache should be checked out and to what local directories.
+#
+# Runs git clone commands using the provided template
+#
+# Usage:
+#     ./git_clone_javadoc.rb 'git clone --branch v%s --depth 1 https://bla.bla %s'
+#     # tokens are branch and dir
+#
+###############################################################################
+
+
+require 'yaml'
+
+if ARGV[0].nil? 
+  puts "Please provide a printf template for the commands to run, see source for details"
+  exit 1
+end
+
+file_content= YAML.load_file("_config.yml")
+
+#for all versions that mention the checkout dir
+file_content['defaults'].find_all{|item| item['values'] && item['values']['ehc_checkout_dir_var']}.each{|item|
+
+  # Look for this variable name in the asciidoctor attributes
+  varname = item['values']['ehc_checkout_dir_var']
+
+  # Asciidoctor attributes are an array of NVP's as strings
+  dir = file_content['asciidoctor']['attributes'].find{|element| element.start_with?("#{varname}=")}.gsub(/.*=\/?/, '')
+
+  version = item['values']['ehc_javadoc_version']
+
+  # p "Found #{dir}, #{version}"
+
+  if version && dir
+    cmd = ARGV[0] % [version, dir]
+    puts "Cloning Version '#{version}' into '#{dir}', Running: #{cmd}"
+    if !system(cmd)
+      puts "Failed to clone!"
+      exit(1)
+    end
+  end
+}
+


### PR DESCRIPTION
…for the jekyll build by parsing the yaml and clone them.

New optional param **ehc_checkout_dir_var** designates that we should look for that variable in the asciidoctor section and check out this version.