### PR TITLE
Add padding-top 3em to all h2, h3, h4 titles

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -593,6 +593,11 @@ pre {
 #content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
 #content h1>a.anchor:before,h2>a.anchor:before,h3>a.anchor:before,#toctitle>a.anchor:before,.sidebarblock>.content>.title>a.anchor:before,h4>a.anchor:before,h5>a.anchor:before,h6>a.anchor:before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
 #content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+.sect1 > h2,
+.sect2 > h3,
+.sect3 > h4 {
+  padding-top: 3em;
+}
 
 #sidebar {
 


### PR DESCRIPTION
@ljacomet  This fixes the scrolling to top problem, when you click on title anchors.

(A similar PR for terracotta.org: https://github.com/Terracotta-OSS/terracotta.org-site/pull/22)