### PR TITLE
Fix version redirection. 

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,11 +1,25 @@
 ---
 ---
   <script type="text/javascript">
-    var splittedURL = window.location.href.split('//')[1].split('/'),
-      len = splittedURL.length;
-    if (splittedURL[1] === 'documentation' && !isNaN(Number(splittedURL[2])) 
-      && /\.html$/gi.test(splittedURL[len - 1].split('#')[0])) {
-      window.location.href = 'http://' + splittedURL.slice(0, 3).join('/');
+    function isRedirect(paramStr) {
+      var splitParamStr = paramStr.split('='),
+        name = splitParamStr[0],
+        value = splitParamStr[1];
+      if (name === 'redirect' && value === 'true') {
+        return true;
+      }
+      return false;
+    }
+
+    var rawSplitURL = window.location.href.split('?'),
+      splitURL = rawSplitURL[0].split('//')[1].split('/');
+
+    if (rawSplitURL.length === 2 && rawSplitURL[1].split('&').some(isRedirect)) {
+        if (splitURL[1] === 'documentation' &&
+          !isNaN(Number(splitURL[2])) &&
+          /\.html$/gi.test(splitURL[splitURL.length - 1].split('#')[0])) {
+          window.location.href = 'http://' + splitURL.slice(0, 3).join('/');
+        }
     }
   </script>
 

--- a/404.html
+++ b/404.html
@@ -1,6 +1,13 @@
 ---
 ---
-
+  <script type="text/javascript">
+    var splittedURL = window.location.href.split('//')[1].split('/'),
+      len = splittedURL.length;
+    if (splittedURL[1] === 'documentation' && !isNaN(Number(splittedURL[2])) 
+      && /\.html$/gi.test(splittedURL[len - 1].split('#')[0])) {
+      window.location.href = 'http://' + splittedURL.slice(0, 3).join('/');
+    }
+  </script>
 
   <div id="intro" class="jumbotron breaker">
     <div class="container">

--- a/_layouts/docs3x_page.html
+++ b/_layouts/docs3x_page.html
@@ -62,9 +62,9 @@ active_menu_id: ehc_mnu_docs
             <span class="current">CURRENT</span>
             {% else %}
             {% if site.documentation.ehcache.future == page.ehc_version %}
-            <span class="future">CURRENT:&nbsp;&nbsp;<a href="{{ page.url  | replace: page.ehc_version, site.documentation.ehcache.future }}">{{site.documentation.ehcache.current}}</a></span>
+            <span class="future">CURRENT:&nbsp;&nbsp;<a href="{{ page.url  | replace: page.ehc_version, site.documentation.ehcache.future }}?redirect=true">{{site.documentation.ehcache.current}}</a></span>
             {% else %}
-            <span class="old">CURRENT:&nbsp;&nbsp;<a href="{{ page.url  | replace: page.ehc_version, site.documentation.ehcache.current }}">{{site.documentation.ehcache.current}}</a></span>
+            <span class="old">CURRENT:&nbsp;&nbsp;<a href="{{ page.url  | replace: page.ehc_version, site.documentation.ehcache.current }}?redirect=true">{{site.documentation.ehcache.current}}</a></span>
             {% endif %}
             {% endif %}
         </h1>

--- a/_layouts/docs3x_page.html
+++ b/_layouts/docs3x_page.html
@@ -62,9 +62,9 @@ active_menu_id: ehc_mnu_docs
             <span class="current">CURRENT</span>
             {% else %}
             {% if site.documentation.ehcache.future == page.ehc_version %}
-            <span class="future">CURRENT:&nbsp;&nbsp;<a href="/documentation/{{site.documentation.ehcache.current}}">{{site.documentation.ehcache.current}}</a></span>
+            <span class="future">CURRENT:&nbsp;&nbsp;<a href="{{ page.url  | replace: page.ehc_version, site.documentation.ehcache.future }}">{{site.documentation.ehcache.current}}</a></span>
             {% else %}
-            <span class="old">CURRENT:&nbsp;&nbsp;<a href="/documentation/{{site.documentation.ehcache.current}}">{{site.documentation.ehcache.current}}</a></span>
+            <span class="old">CURRENT:&nbsp;&nbsp;<a href="{{ page.url  | replace: page.ehc_version, site.documentation.ehcache.current }}">{{site.documentation.ehcache.current}}</a></span>
             {% endif %}
             {% endif %}
         </h1>

--- a/_layouts/docs3x_page.html
+++ b/_layouts/docs3x_page.html
@@ -13,6 +13,21 @@ active_menu_id: ehc_mnu_docs
 
   <div class="row row-offcanvas row-offcanvas-left">
 
+    <!-- version indicator floating box -->
+    <div id="versionIndicator">
+      {% if site.documentation.ehcache.current == page.ehc_version %}
+      You are browsing <span class="current">CURRENT</span> documentation.
+      {% else %}
+      {% if site.documentation.ehcache.future == page.ehc_version %}
+      You are browsing future documentation.<br/>
+      <span class="future">Go to current version:&nbsp;&nbsp;<a href="{{ page.url  | replace: page.ehc_version, site.documentation.ehcache.future }}?redirect=true">{{site.documentation.ehcache.current}}</a></span>
+      {% else %}
+      You are browsing older documentation.<br/>
+      <span class="old">Go to current version:&nbsp;&nbsp;<a href="{{ page.url  | replace: page.ehc_version, site.documentation.ehcache.current }}?redirect=true">{{site.documentation.ehcache.current}}</a></span>
+      {% endif %}
+      {% endif %}
+    </div>
+
     <!-- sidebar -->
     <div class="col-xs-6 col-sm-3 sidebar-offcanvas" id="sidebar" role="navigation">
         <ul class="nav">
@@ -58,15 +73,6 @@ active_menu_id: ehc_mnu_docs
         {% if page.no_title_on_main_layout %} {% else %}
         <h1 class="post-title">
             <span>{% if page.visible_title %}{{ page.visible_title  | replace: '!DOC_VERSION!', page.ehc_version }} {% else %}{{ page.title  | replace: '!DOC_VERSION!', page.ehc_version }}{% endif %}</span>
-            {% if site.documentation.ehcache.current == page.ehc_version %}
-            <span class="current">CURRENT</span>
-            {% else %}
-            {% if site.documentation.ehcache.future == page.ehc_version %}
-            <span class="future">CURRENT:&nbsp;&nbsp;<a href="{{ page.url  | replace: page.ehc_version, site.documentation.ehcache.future }}?redirect=true">{{site.documentation.ehcache.current}}</a></span>
-            {% else %}
-            <span class="old">CURRENT:&nbsp;&nbsp;<a href="{{ page.url  | replace: page.ehc_version, site.documentation.ehcache.current }}?redirect=true">{{site.documentation.ehcache.current}}</a></span>
-            {% endif %}
-            {% endif %}
         </h1>
         <hr/>
         {% endif %}

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -682,22 +682,25 @@ pre {
 }
 
 .ehcache-documentation {
-
+  #versionIndicator {
+    position: fixed;
+    bottom: 1em;
+    left: 1em;
+    background-color: antiquewhite;
+    text-align: center;
+    color: gray;
+    font-size: 14px;
+    z-index: 10;
+    border-radius: 10px;
+    padding: .5em .5em .5em .5em;
+  }
   .current {
-    float: right;
     color: limegreen;
-    font-size: 14px;
   }
-
   .future {
-    float: right;
     color: orange;
-    font-size: 14px;
   }
-
   .old {
-    float: right;
     color: red;
-    font-size: 14px;
   }
 }


### PR DESCRIPTION
@ljacomet This PR fixes the version redirection issue: when you are looking at version 3.0 docs, you can click on the current version link, and redirect to the 3.1 version of the same doc; If the doc doesn't exist in the new version, it will redirect to the documentation index page.

Please ping me if there is any question, I can do a demo if you want.
