### PR TITLE
KryoSerializer now supports objects bigger than 4096 bytes

### DIFF
--- a/_posts/blog/2016-05-12-ehcache3-serializers.adoc
+++ b/_posts/blog/2016-05-12-ehcache3-serializers.adoc
@@ -470,10 +470,8 @@ public class KryoSerializer implements Serializer<Employee> {
 
   @Override
   public ByteBuffer serialize(final Employee object) throws SerializerException {
-    Output output = new Output(new ByteArrayOutputStream());
+    Output output = new Output(4096);
     kryo.writeObject(output, object);
-    output.close();
-
     return ByteBuffer.wrap(output.getBuffer());
   }
 


### PR DESCRIPTION
com.esotericsoftware.kryo.io.Output will overflow to the supplied stream when the internal buffer is full. The default internal buffer size is 4096 bytes. output.getBuffer() contains the last bytes not yet flushed to the other byte stream. If the object size exceeds the internal buffer size, the return value of output.getBuffer() will not contain all object bytes.

Supplying another ByteArrayOutputStream also leads to unnecessary byte array copies between Output and ByteArrayOutputStream each time the buffer overflows. 

Output grows the internal buffer when necessary when no upper limit is specified. Providing a reasonable initial size also reduces the amount of buffer re-allocations.