### PR TITLE
Updated to remove link to Replication Guide - 

### DIFF
--- a/documentation/2.10.4/pdf/index.md
+++ b/documentation/2.10.4/pdf/index.md
@@ -12,7 +12,6 @@
 |<a href="/generated/2.10.4/pdf/Ehcache_API_Developer_Guide.pdf" target="_blank">Ehcache API Developer Guide</a>|
 |<a href="/generated/2.10.4/pdf/Ehcache_Configuration_Guide.pdf" target="_blank">Ehcache Configuration Guide</a>|
 |<a href="/generated/2.10.4/pdf/Ehcache_Operations_Guide.pdf" target="_blank">Ehcache Operations Guide</a>|
-|<a href="/generated/2.10.4/pdf/Ehcache_Replication_Guide.pdf" target="_blank">Ehcache Replication Guide</a>|
 |<a href="/generated/2.10.4/pdf/Ehcache_Web_Cache_User_Guide.pdf" target="_blank">Ehcache Web Cache User Guide</a>|
 |<a href="/generated/2.10.4/pdf/Ehcache_Cache_Server_User_Guide.pdf" target="_blank">Ehcache Cache Server User Guide</a>|
 |<a href="/generated/2.10.4/pdf/Integrations.pdf" target="_blank">Integrations</a>|


### PR DESCRIPTION
per request of Alex  Crook  "The Ehcache Replication Guide has become obsolete since SEP 2016 and has been removed from all deliveries on the corporate site. "